### PR TITLE
Implement TCP reusable socket binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,9 +457,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ amplify = "4.0.0"
 io-reactor = { version = "0.2.0", optional = true }
 cyphernet = { version = "0.3.0", features = ["ed25519", "pem", "multibase", "noise_sha2", "noise_x25519", "noise-framework", "mixnets", "dns"] }
 mio = { version = "0.8.6", optional = true }
-socket2 = { version = "0.5.2", optional = true }
+socket2 = { version = "0.5.2", optional = true, features = ["all"] }
 libc = "0.2.138"
 log_crate = { package = "log", version = "0.4.17", optional = true }
 rand = "0.8.5" # Used in SplitIo shared secret

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ log_crate = { package = "log", version = "0.4.17" }
 
 [features]
 default = ["reactor", "socket2"]
-all = ["reactor", "connect_nonblocking", "eidolon", "mio", "log"]
+all = ["reactor", "nonblocking", "eidolon", "mio", "log"]
 eidolon = ["cyphernet/eidolon"]
-reactor = ["io-reactor", "connect_nonblocking"]
-connect_nonblocking = ["socket2"]
+reactor = ["io-reactor", "nonblocking"]
+nonblocking = ["socket2"]
 log = ["log_crate", "io-reactor/log"]
 
 [package.metadata.docs.rs]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -45,7 +45,7 @@ pub trait NetConnection: NetStream + AsRawFd + Debug {
     fn connect_blocking(addr: Self::Addr) -> io::Result<Self>
     where Self: Sized;
 
-    #[cfg(feature = "connect_nonblocking")]
+    #[cfg(feature = "nonblocking")]
     fn connect_nonblocking(addr: Self::Addr) -> io::Result<Self>
     where Self: Sized;
 
@@ -78,7 +78,7 @@ impl NetConnection for TcpStream {
 
     fn connect_blocking(addr: Self::Addr) -> io::Result<Self> { TcpStream::connect(addr) }
 
-    #[cfg(feature = "connect_nonblocking")]
+    #[cfg(feature = "nonblocking")]
     fn connect_nonblocking(addr: Self::Addr) -> io::Result<Self> {
         Ok(socket2::Socket::connect_nonblocking(addr)?.into())
     }
@@ -128,7 +128,7 @@ impl NetConnection for socket2::Socket {
         TcpStream::connect(addr).map(socket2::Socket::from)
     }
 
-    #[cfg(feature = "connect_nonblocking")]
+    #[cfg(feature = "nonblocking")]
     fn connect_nonblocking(addr: Self::Addr) -> io::Result<Self> {
         use std::net::ToSocketAddrs;
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -49,6 +49,14 @@ pub trait NetConnection: NetStream + AsRawFd + Debug {
     fn connect_nonblocking(addr: Self::Addr) -> io::Result<Self>
     where Self: Sized;
 
+    #[cfg(feature = "nonblocking")]
+    fn connect_reusable_nonblocking(
+        local_addr: Self::Addr,
+        remote_addr: Self::Addr,
+    ) -> io::Result<Self>
+    where
+        Self: Sized;
+
     fn shutdown(&mut self, how: Shutdown) -> io::Result<()>;
 
     fn remote_addr(&self) -> Self::Addr;
@@ -81,6 +89,14 @@ impl NetConnection for TcpStream {
     #[cfg(feature = "nonblocking")]
     fn connect_nonblocking(addr: Self::Addr) -> io::Result<Self> {
         Ok(socket2::Socket::connect_nonblocking(addr)?.into())
+    }
+
+    #[cfg(feature = "nonblocking")]
+    fn connect_reusable_nonblocking(
+        local_addr: Self::Addr,
+        remote_addr: Self::Addr,
+    ) -> io::Result<Self> {
+        Ok(socket2::Socket::connect_reusable_nonblocking(local_addr, remote_addr)?.into())
     }
 
     fn shutdown(&mut self, how: Shutdown) -> io::Result<()> { TcpStream::shutdown(self, how) }
@@ -157,6 +173,55 @@ impl NetConnection for socket2::Socket {
             Err(e) => {
                 #[cfg(feature = "log")]
                 log::debug!(target: "netservices", "Error connecting to {}: {}", addr, e);
+                return Err(e);
+            }
+        }
+        Ok(socket)
+    }
+
+    fn connect_reusable_nonblocking(
+        local_addr: Self::Addr,
+        remote_addr: Self::Addr,
+    ) -> io::Result<Self> {
+        use std::net::ToSocketAddrs;
+
+        let local_addr = local_addr.to_socket_addrs()?.next().ok_or(io::ErrorKind::InvalidInput)?;
+        let remote_addr =
+            remote_addr.to_socket_addrs()?.next().ok_or(io::ErrorKind::AddrNotAvailable)?;
+        let socket = socket2::Socket::new(
+            socket2::Domain::for_address(local_addr),
+            socket2::Type::STREAM,
+            None,
+        )?;
+        socket.set_nonblocking(true)?;
+        socket.set_reuse_address(true)?;
+        #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
+        {
+            socket.set_reuse_port(true)?;
+        }
+        socket2::Socket::bind(&socket, &local_addr.into())?;
+
+        match socket2::Socket::connect(&socket, &remote_addr.into()) {
+            Ok(()) => {
+                #[cfg(feature = "log")]
+                log::debug!(target: "netservices", "Connected to {}", remote_addr);
+            }
+            Err(e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {
+                #[cfg(feature = "log")]
+                log::debug!(target: "netservices", "Connecting to {} in a non-blocking way", remote_addr);
+            }
+            Err(e) if e.raw_os_error() == Some(libc::EALREADY) => {
+                #[cfg(feature = "log")]
+                log::error!(target: "netservices", "Can't connect to {}: address already in use", remote_addr);
+                return Err(io::Error::from(io::ErrorKind::AlreadyExists));
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                #[cfg(feature = "log")]
+                log::error!(target: "netservices", "Can't connect to {} in a non-blocking way", remote_addr);
+            }
+            Err(e) => {
+                #[cfg(feature = "log")]
+                log::debug!(target: "netservices", "Error connecting to {}: {}", remote_addr, e);
                 return Err(e);
             }
         }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -75,7 +75,7 @@ impl NetListener for TcpListener {
     fn take_error(&self) -> io::Result<Option<io::Error>> { TcpListener::take_error(self) }
 }
 
-#[cfg(feature = "connect_nonblocking")]
+#[cfg(feature = "nonblocking")]
 impl NetListener for socket2::Socket {
     type Stream = socket2::Socket;
 

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -31,6 +31,10 @@ pub trait NetListener: AsRawFd + Send {
     fn bind(addr: &impl ToSocketAddrs) -> io::Result<Self>
     where Self: Sized;
 
+    #[cfg(feature = "nonblocking")]
+    fn bind_reusable(addr: &impl ToSocketAddrs) -> io::Result<Self>
+    where Self: Sized;
+
     fn accept(&self) -> io::Result<Self::Stream>;
 
     fn local_addr(&self) -> SocketAddr;
@@ -51,6 +55,18 @@ impl NetListener for TcpListener {
     fn bind(addr: &impl ToSocketAddrs) -> io::Result<Self>
     where Self: Sized {
         TcpListener::bind(addr)
+    }
+
+    #[cfg(feature = "nonblocking")]
+    fn bind_reusable(addr: &impl ToSocketAddrs) -> io::Result<Self>
+    where Self: Sized {
+        // This is the default used by std::net::TcpListener at the time of writing. Unfortunately
+        // the standard library doesn't export this value so we have to hard-code it here.
+        const BACKLOG: i32 = 128;
+
+        let socket = socket2::Socket::bind_reusable(addr)?;
+        socket.listen(BACKLOG)?;
+        Ok(TcpListener::from(socket))
     }
 
     fn accept(&self) -> io::Result<Self::Stream> { Ok(TcpListener::accept(self)?.0) }
@@ -84,6 +100,20 @@ impl NetListener for socket2::Socket {
         let addr = addr.to_socket_addrs()?.next().ok_or(io::ErrorKind::InvalidInput)?;
         let socket =
             socket2::Socket::new(socket2::Domain::for_address(addr), socket2::Type::STREAM, None)?;
+        socket2::Socket::bind(&socket, &addr.into())?;
+        Ok(socket)
+    }
+
+    fn bind_reusable(addr: &impl ToSocketAddrs) -> io::Result<Self>
+    where Self: Sized {
+        let addr = addr.to_socket_addrs()?.next().ok_or(io::ErrorKind::InvalidInput)?;
+        let socket =
+            socket2::Socket::new(socket2::Domain::for_address(addr), socket2::Type::STREAM, None)?;
+        socket.set_reuse_address(true)?;
+        #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
+        {
+            socket.set_reuse_port(true)?;
+        }
         socket2::Socket::bind(&socket, &addr.into())?;
         Ok(socket)
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -122,6 +122,19 @@ impl<L: NetListener<Stream = S::Connection>, S: NetSession> NetAccept<S, L> {
         })
     }
 
+    /// Binds listener to the provided socket address(es) with a given context. Same as
+    /// [`NetAccept::bind`] except that it uses `SO_REUSEADDR`/`SO_REUSEPORT` to enable more
+    /// sockets to bound to the same address.
+    #[cfg(feature = "nonblocking")]
+    pub fn bind_reusable(addr: &impl ToSocketAddrs) -> io::Result<Self> {
+        let listener = L::bind_reusable(addr)?;
+        listener.set_nonblocking(true)?;
+        Ok(Self {
+            listener,
+            _phantom: default!(),
+        })
+    }
+
     /// Returns the local [`net::SocketAddr`] on which listener accepts
     /// connections.
     pub fn local_addr(&self) -> net::SocketAddr { self.listener.local_addr() }

--- a/src/split.rs
+++ b/src/split.rs
@@ -138,7 +138,7 @@ impl SplitIo for TcpStream {
     }
 }
 
-#[cfg(feature = "connect_nonblocking")]
+#[cfg(feature = "nonblocking")]
 impl SplitIo for socket2::Socket {
     type Read = TcpReader<Self>;
     type Write = TcpWriter<Self>;


### PR DESCRIPTION
This PR adds `bind_reusable` and `connect_reusable_nonblocking` methods to listeners and streams. These methods set `SO_REUSEADDR` and `SO_REUSEPORT` on the socket before binding it to the local address. `connect_reusable_nonblocking` also allows specifying the local address to make the connection from. Together these methods enable receiving incoming connections and making outgoing connections from the same port which is necessary for TCP hole punching.

The first commit here removes the `socket2`/`connect_nonblocking` features because I needed `socket2` to implement these methods and I couldn't see the point in keeping these features if `socket2` would have to be a dependency anyway. Alternatively I could scrap that commit and put the new methods behind another feature gate (a la `connect_nonblocking`) if that's preferred.

ping @cloudhead