### PR TITLE
Make NetConnection local and remote address failable

### DIFF
--- a/src/resource.rs
+++ b/src/resource.rs
@@ -497,7 +497,7 @@ impl<S: NetSession> Write for NetTransport<S> {
 
     fn flush(&mut self) -> io::Result<()> {
         let res = self.flush_buffer();
-        self.session.flush().and_then(|_| res)
+        self.session.flush().and(res)
     }
 }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -312,7 +312,7 @@ impl<S: NetSession> NetTransport<S> {
     pub fn is_outbound(&self) -> bool { self.link_direction() == Direction::Outbound }
     pub fn link_direction(&self) -> Direction { self.link_direction }
 
-    pub fn local_addr(&self) -> <S::Connection as NetConnection>::Addr {
+    pub fn local_addr(&self) -> io::Result<<S::Connection as NetConnection>::Addr> {
         self.session.as_connection().local_addr()
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -610,9 +610,9 @@ mod impl_noise {
         pub fn to_vec(&self) -> Vec<u8> {
             let mut vec = Vec::<u8>::with_capacity(D::OUTPUT_LEN + E::Pk::COMPRESSED_LEN);
             vec.extend_from_slice(self.handshake_hash.as_ref());
-            self.remote_static_key
-                .as_ref()
-                .map(|pk| vec.extend_from_slice(pk.to_pk_compressed().as_ref()));
+            if let Some(pk) = self.remote_static_key.as_ref() {
+                vec.extend_from_slice(pk.to_pk_compressed().as_ref())
+            }
             vec
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -150,16 +150,16 @@ impl<I: EcSign, D: Digest> CypherSession<I, D> {
         cert: Cert<I::Sig>,
         allowed_ids: Vec<I::Pk>,
         signer: I,
-    ) -> Self {
-        Self::with_config::<HASHLEN>(
-            connection.remote_addr().into(),
+    ) -> io::Result<Self> {
+        Ok(Self::with_config::<HASHLEN>(
+            connection.remote_addr()?.into(),
             connection,
             Direction::Inbound,
             cert,
             allowed_ids,
             signer,
             false,
-        )
+        ))
     }
 
     fn with_config<const HASHLEN: usize>(


### PR DESCRIPTION
Closes #37

This doesn't touch `NetListener::local_addr` since (1) it will still have to panic due `Resource::id` implementation and (2) I assume there is no conditions under which the listener local address method should fail